### PR TITLE
Add -for-grype suffix to Merged VEX name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -104,7 +104,7 @@ runs:
       id: merge-vex
       uses: telicent-oss/merge-vex-action@v1
       with:
-        name: ${{ inputs.scan-name }}
+        name: ${{ inputs.scan-name }}-for-grype
         remote-vex: ${{ inputs.remote-vex }}
 
     - name: Generate Grype Ignore file


### PR DESCRIPTION
This avoid potential naming conflicts with Merged VEX artefacts generated by telicent-oss/trivy-action