### PR TITLE
Cache grype executable

### DIFF
--- a/.github/workflows/self-tests.yml
+++ b/.github/workflows/self-tests.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   cache-images:
     runs-on: ubuntu-latest

--- a/.github/workflows/self-tests.yml
+++ b/.github/workflows/self-tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: [ "telicent/telicent-java21:1.2.45", "telicent/telicent-access-api:1.4.2", "alpine:3.23.4" ]
+        image: [ "telicent/telicent-java21:1.2.50", "telicent/telicent-access-api:1.4.2", "alpine:3.24.0" ]
       fail-fast: true
     steps:
       - name: Cache Images
@@ -30,7 +30,7 @@ jobs:
     needs: cache-images
     strategy:
       matrix:
-        image: [ "telicent/telicent-java21:1.2.45", "alpine:3.23.4" ]
+        image: [ "telicent/telicent-java21:1.2.50", "alpine:3.24.0" ]
       fail-fast: false
     steps:
       - name: Checkout
@@ -74,7 +74,7 @@ jobs:
       - name: Restore Cached Image
         uses: telicent-oss/docker-image-cache-action@v1
         with:
-          images: telicent/telicent-java21:1.2.45
+          images: telicent/telicent-java21:1.2.50
           restore-only: true
         
       - name: Grype Image Scan that Passes
@@ -82,7 +82,7 @@ jobs:
         uses: telicent-oss/grype-action@v1
         with:
           scan-type: image
-          scan-ref: telicent/telicent-java21:1.2.45
+          scan-ref: telicent/telicent-java21:1.2.50
           scan-name: good-scan
           remote-vex: telicent-oss/telicent-base-images
 
@@ -101,7 +101,7 @@ jobs:
       - name: Restore Cached Image
         uses: telicent-oss/docker-image-cache-action@v1
         with:
-          images: telicent/telicent-java21:1.2.40
+          images: telicent/telicent-java21:1.2.50
           restore-only: true
 
       - name: Grype Image Scan that Passes
@@ -109,7 +109,7 @@ jobs:
         uses: telicent-oss/grype-action@v1
         with:
           scan-type: image
-          scan-ref: telicent/telicent-java21:1.2.40
+          scan-ref: telicent/telicent-java21:1.2.50
           scan-name: remote-vex-telicent-java21
           remote-vex: |
             telicent-oss/grype-action
@@ -245,5 +245,75 @@ jobs:
         if: ${{ failure() && steps.grype-scan.outcome != 'failed' }}
         run: |
           exit 1
+
+  grype-executable-caching:
+    runs-on: ubuntu-latest
+    needs: cache-images
+    steps:
+      # Need to checkout as we need the VEX statements for the scan to pass!
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3.3.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Restore Cached Image
+        uses: telicent-oss/docker-image-cache-action@v1
+        with:
+          images: telicent/telicent-java21:1.2.50
+          restore-only: true
+        
+      - name: Grype Image Scan that Passes
+        id: grype-scan
+        uses: telicent-oss/grype-action@cache-executable
+        with:
+          scan-type: image
+          scan-ref: telicent/telicent-java21:1.2.50
+          scan-name: good-scan
+          remote-vex: telicent-oss/telicent-base-images
+
+      # The GitHub Actions Runner tool cache directory uses lower case arch identifiers BUT runner.arch reports upper case
+      # identifiers so have to lowercase the value so that we can generate the correct installation path that such that
+      # the Grype action finds the pre-installed executable and doesn't need to reinstall it again
+      - name: Lowercase Architecture
+        id: detect-arch
+        shell: bash
+        run: |
+          LOWER_ARCH=$(echo "{{ runner.arch }}" | tr '[:upper:]' '[:lower:]')
+          echo "arch=${LOWER_ARCH}" >> $GITHUB_OUTPUT
+
+      - name: Verify Grype executable now in the cache
+        uses: actions/cache@v5
+        with:
+          key: grype-executable-v0.92.2-${{ runner.os }}-${{ steps.detect-arch.outputs.arch }}
+          path: ${{ runner.tool_cache }}/grype/0.92.2/${{ steps.detect-arch.outputs.arch }}/grype
+          lookup-only: true
+          fail-on-cache-miss: true
+
+  grype-executable-reuse:
+    runs-on: ubuntu-latest
+    needs: grype-executable-caching
+    steps:
+      # The GitHub Actions Runner tool cache directory uses lower case arch identifiers BUT runner.arch reports upper case
+      # identifiers so have to lowercase the value so that we can generate the correct installation path that such that
+      # the Grype action finds the pre-installed executable and doesn't need to reinstall it again
+      - name: Lowercase Architecture
+        id: detect-arch
+        shell: bash
+        run: |
+          LOWER_ARCH=$(echo "{{ runner.arch }}" | tr '[:upper:]' '[:lower:]')
+          echo "arch=${LOWER_ARCH}" >> $GITHUB_OUTPUT
+
+      - name: Verify Grype executable available in the cache
+        uses: actions/cache@v5
+        with:
+          key: grype-executable-v0.92.2-${{ runner.os }}-${{ steps.detect-arch.outputs.arch }}
+          path: ${{ runner.tool_cache }}/grype/0.92.2/${{ steps.detect-arch.outputs.arch }}/grype
+          lookup-only: true
+          fail-on-cache-miss: true
+
 
 

--- a/.github/workflows/self-tests.yml
+++ b/.github/workflows/self-tests.yml
@@ -268,7 +268,7 @@ jobs:
         
       - name: Grype Image Scan that Passes
         id: grype-scan
-        uses: telicent-oss/grype-action@cache-executable
+        uses: telicent-oss/grype-action@v1
         with:
           scan-type: image
           scan-ref: telicent/telicent-java21:1.2.50

--- a/.github/workflows/self-tests.yml
+++ b/.github/workflows/self-tests.yml
@@ -282,7 +282,7 @@ jobs:
         id: detect-arch
         shell: bash
         run: |
-          LOWER_ARCH=$(echo "{{ runner.arch }}" | tr '[:upper:]' '[:lower:]')
+          LOWER_ARCH=$(echo "${{ runner.arch }}" | tr '[:upper:]' '[:lower:]')
           echo "arch=${LOWER_ARCH}" >> $GITHUB_OUTPUT
 
       - name: Verify Grype executable now in the cache
@@ -304,7 +304,7 @@ jobs:
         id: detect-arch
         shell: bash
         run: |
-          LOWER_ARCH=$(echo "{{ runner.arch }}" | tr '[:upper:]' '[:lower:]')
+          LOWER_ARCH=$(echo "${{ runner.arch }}" | tr '[:upper:]' '[:lower:]')
           echo "arch=${LOWER_ARCH}" >> $GITHUB_OUTPUT
 
       - name: Verify Grype executable available in the cache

--- a/.github/workflows/self-tests.yml
+++ b/.github/workflows/self-tests.yml
@@ -288,8 +288,8 @@ jobs:
       - name: Verify Grype executable now in the cache
         uses: actions/cache@v5
         with:
-          key: grype-executable-v0.92.2-${{ runner.os }}-${{ steps.detect-arch.outputs.arch }}
-          path: ${{ runner.tool_cache }}/grype/0.92.2/${{ steps.detect-arch.outputs.arch }}/grype
+          key: grype-executable-v0.107.0-${{ runner.os }}-${{ steps.detect-arch.outputs.arch }}
+          path: ${{ runner.tool_cache }}/grype/0.107.0/${{ steps.detect-arch.outputs.arch }}/grype
           lookup-only: true
           fail-on-cache-miss: true
 
@@ -310,8 +310,8 @@ jobs:
       - name: Verify Grype executable available in the cache
         uses: actions/cache@v5
         with:
-          key: grype-executable-v0.92.2-${{ runner.os }}-${{ steps.detect-arch.outputs.arch }}
-          path: ${{ runner.tool_cache }}/grype/0.92.2/${{ steps.detect-arch.outputs.arch }}/grype
+          key: grype-executable-v0.107.0-${{ runner.os }}-${{ steps.detect-arch.outputs.arch }}
+          path: ${{ runner.tool_cache }}/grype/0.107.0/${{ steps.detect-arch.outputs.arch }}/grype
           lookup-only: true
           fail-on-cache-miss: true
 

--- a/action.yml
+++ b/action.yml
@@ -141,12 +141,36 @@ runs:
         fi
         echo ""
 
+    # The GitHub Actions Runner tool cache directory uses lower case arch identifiers BUT runner.arch reports upper case
+    # identifiers so have to lowercase the value so that we can generate the correct installation path that such that
+    # the Grype action finds the pre-installed executable and doesn't need to reinstall it again
+    - name: Lowercase Architecture
+      id: detect-arch
+      shell: bash
+      run: |
+        LOWER_ARCH=$(echo "{{ runner.arch }}" | tr '[:upper:]' '[:lower:]')
+        echo "arch=${LOWER_ARCH}" >> $GITHUB_OUTPUT
+
+    - name: Restore Grype executable from Cache
+      id: restore-grype
+      uses: actions/cache/restore@v5
+      with:
+        key: grype-executable-v0.92.2-${{ runner.os }}-${{ steps.detect-arch.outputs.arch }}
+        path: ${{ runner.tool_cache }}/grype/0.92.2/${{ steps.detect-arch.outputs.arch }}/grype
+
     - name: Setup Grype
       id: setup-grype
       uses: anchore/scan-action/download-grype@v7
       with:
         grype-version: v0.107.0
         cache-db: true
+
+    - name: Save installed Grype executable to Cache
+      if: ${{ steps.restore-grype.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@v5
+      with:
+        key: grype-executable-v0.92.2-${{ runner.os }}-${{ steps.detect-arch.outputs.arch }}
+        path: ${{ runner.tool_cache }}/grype/0.92.2/${{ steps.detect-arch.outputs.arch }}/grype
 
     # Perform a full vulnerability to generate a full vulnerability report
     - name: Grype Vulnerability Scan

--- a/action.yml
+++ b/action.yml
@@ -148,7 +148,7 @@ runs:
       id: detect-arch
       shell: bash
       run: |
-        LOWER_ARCH=$(echo "{{ runner.arch }}" | tr '[:upper:]' '[:lower:]')
+        LOWER_ARCH=$(echo "${{ runner.arch }}" | tr '[:upper:]' '[:lower:]')
         echo "arch=${LOWER_ARCH}" >> $GITHUB_OUTPUT
 
     - name: Restore Grype executable from Cache

--- a/action.yml
+++ b/action.yml
@@ -54,6 +54,11 @@ inputs:
       Specifies whether it is permitted for the action to pass if it detects High/Critical 
       vulnerabilities that do not currently have a fix i.e. there is not necessarily anything
       we could do to resolve them at this time.
+  grype-version:
+    required: false
+    default: "0.107.0"
+    description: |
+      Specifies the version of Grype to be installed and used without the leading `v`
 outputs:
   scan-results:
     value: ${{ steps.generate-outputs.outputs.scan-results }}
@@ -155,22 +160,22 @@ runs:
       id: restore-grype
       uses: actions/cache/restore@v5
       with:
-        key: grype-executable-v0.92.2-${{ runner.os }}-${{ steps.detect-arch.outputs.arch }}
-        path: ${{ runner.tool_cache }}/grype/0.92.2/${{ steps.detect-arch.outputs.arch }}/grype
+        key: grype-executable-v${{ inputs.grype-version }}-${{ runner.os }}-${{ steps.detect-arch.outputs.arch }}
+        path: ${{ runner.tool_cache }}/grype/${{ inputs.grype-version}}/${{ steps.detect-arch.outputs.arch }}/grype
 
     - name: Setup Grype
       id: setup-grype
       uses: anchore/scan-action/download-grype@v7
       with:
-        grype-version: v0.107.0
+        grype-version: v${{ inputs.grype-version }}
         cache-db: true
 
     - name: Save installed Grype executable to Cache
       if: ${{ steps.restore-grype.outputs.cache-hit != 'true' }}
       uses: actions/cache/save@v5
       with:
-        key: grype-executable-v0.92.2-${{ runner.os }}-${{ steps.detect-arch.outputs.arch }}
-        path: ${{ runner.tool_cache }}/grype/0.92.2/${{ steps.detect-arch.outputs.arch }}/grype
+        key: grype-executable-v${{ inputs.grype-version }}-${{ runner.os }}-${{ steps.detect-arch.outputs.arch }}
+        path: ${{ runner.tool_cache }}/grype/${{ inputs.grype-version }}/${{ steps.detect-arch.outputs.arch }}/grype
 
     # Perform a full vulnerability to generate a full vulnerability report
     - name: Grype Vulnerability Scan
@@ -187,7 +192,7 @@ runs:
         # Don't want to fail the build yet, just getting the full report for now
         fail-build: false
         # Restore the Cached Grype vulnerability database
-        grype-version: v0.92.2
+        grype-version: v${{ inputs.grype-version }}
         cache-db: true
 
     - name: Upload Vulnerability Scan Results
@@ -234,7 +239,7 @@ runs:
         fail-build: true
         only-fixed: ${{ inputs.allow-unfixed }}
         # Restore the Cached Grype vulnerability database
-        grype-version: v0.102.0
+        grype-version: v${{ inputs.grype-version }}
         cache-db: true
 
     - name: Display Gating Vulnerabilities in Job Summary (if any)


### PR DESCRIPTION
The Grype scan action reuses the Grype executable from the GitHub Runner tool cache if present so add steps to explicit restore and save this location as needed to avoid needing to re-install Grype directly on every scan