### PR TITLE
Ensure Grype summaries are displayed (attempt 2)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -246,7 +246,7 @@ runs:
       if: ${{ always() }}
       shell: bash
       run: |
-        if [ -f "${RUNNER_TEMP}/${{ steps.sanitised.outputs.artifact_name }}-grype-gating-report.json" ]; then
+        if [ -f "${RUNNER_TEMP}/${{ steps.sanitised.outputs.file_prefix }}-grype-gating-report.json" ]; then
           echo "# Grype \`${{ inputs.scan-type }}\` scan on \`${{inputs.scan-ref }}\`" >> "$GITHUB_STEP_SUMMARY"
           SCAN_ARG=""
           case "${{ inputs.scan-type }}" in


### PR DESCRIPTION
Was still using the wrong output variable in checking whether the gating report existing and thus the GitHub job summary should be added